### PR TITLE
FIX: option parser set update

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,9 +10,8 @@ In your `$XDG_CONFIG_HOME` (or `$HOME/.config`) create `iosevka/config`, in INI 
 ```ini
 [options]
     name = myosevka
-    sans =
-    stress-fw =
-    type =
+    sans
+    stress-fw
     ligset = haskell
 
 [common]
@@ -30,9 +29,6 @@ In your `$XDG_CONFIG_HOME` (or `$HOME/.config`) create `iosevka/config`, in INI 
     g = opendoublestory
     numbersign = slanted
 ```
-
-Note:
-  - `spacing = term` is equivalent to `ligset =;`, i.e. empty, or a comment (`;`)
 
 Details of the (growing) options available can be found in the [font's readme][Iosevka].
 

--- a/iosevka-generate
+++ b/iosevka-generate
@@ -87,9 +87,9 @@ def parse_config(config_file: os.PathLike) -> Tuple[str, Dict[str, Set[str]]]:
         if option == 'name':
             font_name = value
         elif value is None:
-            font_styles['common'].update(option)
+            font_styles['common'].add(option)
         else:
-            font_styles['common'].update(f'{option}-{value}')
+            font_styles['common'].add(f'{option}-{value}')
 
     return (font_name, font_styles)
 


### PR DESCRIPTION
There is a bug in the option parser code.
set.update() with a string argument inserts single chars into the set.
I updated the README.md as well to account for the necessary changes.