### PR TITLE
Fix: use modern iosevka build-plans format

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,7 @@ In your `$XDG_CONFIG_HOME` (or `$HOME/.config`) create `iosevka/my-font.toml` in
 ```ini
 [options]
     name = myosevka
-    sans
-    stress-fw
+    serifs = sans
     ligset = haskell
     nerdfont = fontawesome powerline material octicons
 

--- a/iosevka-generate
+++ b/iosevka-generate
@@ -55,14 +55,28 @@ def generate_font_plan(
     print(f"Building font with family name: {family_name}")
 
     with open(iosevka_dir / "private-build-plans.toml", "w") as fp:
-        conf = f"""\
-            [buildPlans.{font_name}]
-            family = "{family_name}"
-            design = [{', '.join(map(lambda style: f'"{style}"', font_styles['common']))}]
-            upright = [{', '.join(map(lambda style: f'"{style}"', font_styles['upright']))}]
-            italic = [{', '.join(map(lambda style: f'"{style}"', font_styles['italic']))}]
-            oblique = [{', '.join(map(lambda style: f'"{style}"', font_styles['oblique']))}]
-        """
+        conf = "\n".join(
+            [
+                f"[buildPlans.{font_name}]",
+                f'serifs = "{" ".join(font_styles["serifs"])}"',
+                f'family = "{font_name}"',
+                "",
+                f"[buildPlans.{font_name}.variants.design]",
+                *font_styles["common"],
+                "",
+                f"[buildPlans.{font_name}.variants.upright]",
+                *font_styles["upright"],
+                "",
+                f"[buildPlans.{font_name}.variants.italic]",
+                *font_styles["italic"],
+                "",
+                f"[buildPlans.{font_name}.variants.oblique]",
+                *font_styles["oblique"],
+                "",
+                f"[buildPlans.{font_name}.ligations]",
+                f'inherits = "{" ".join(font_styles["ligations"])}"',
+            ]
+        )
 
         print(f"Building iosevka conf:\n{conf}", file=sys.stderr)
         fp.write(dedent(conf))
@@ -106,12 +120,12 @@ def parse_config(config_file: Path) -> Tuple[str, Dict[str, Set[str]], Optional[
     )
     config.read_dict({"options": {"name": "myosevka"}})
 
-    sections = {"common", "upright", "italic", "oblique"}
+    sections = {"common", "upright", "italic", "oblique", "ligations", "serifs"}
     config.read_dict({s: {} for s in sections})
     config.read(config_file)
 
     font_styles = {
-        section: {f"v-{char}-{style}" for char, style in config[section].items()}
+        section: {f'{char} = "{style}"' for char, style in config[section].items()}
         for section in sections
     }
 
@@ -121,10 +135,10 @@ def parse_config(config_file: Path) -> Tuple[str, Dict[str, Set[str]], Optional[
             font_name = value
         elif option == "nerdfont":
             nerdfont = value.split(" ")
-        elif not value:
-            font_styles["common"].add(option)
-        else:
-            font_styles["common"].add(f"{option}-{value}")
+        elif option == "ligset":
+            font_styles["ligations"].add(option)
+        elif option == "serifs":
+            font_styles["serifs"].add(option)
 
     return (font_name, font_styles, nerdfont)
 

--- a/iosevka-generate
+++ b/iosevka-generate
@@ -58,8 +58,8 @@ def generate_font_plan(
         conf = "\n".join(
             [
                 f"[buildPlans.{font_name}]",
-                f'serifs = "{" ".join(font_styles["serifs"])}"',
                 f'family = "{font_name}"',
+                *font_styles["options"],
                 "",
                 f"[buildPlans.{font_name}.variants.design]",
                 *font_styles["common"],
@@ -120,12 +120,14 @@ def parse_config(config_file: Path) -> Tuple[str, Dict[str, Set[str]], Optional[
     )
     config.read_dict({"options": {"name": "myosevka"}})
 
-    sections = {"common", "upright", "italic", "oblique", "ligations", "serifs"}
+    sections = {"common", "upright", "italic", "oblique", "ligations", "options"}
     config.read_dict({s: {} for s in sections})
     config.read(config_file)
 
     font_styles = {
         section: {f'{char} = "{style}"' for char, style in config[section].items()}
+        if section != "options"
+        else set()
         for section in sections
     }
 
@@ -137,8 +139,8 @@ def parse_config(config_file: Path) -> Tuple[str, Dict[str, Set[str]], Optional[
             nerdfont = value.split(" ")
         elif option == "ligset":
             font_styles["ligations"].add(option)
-        elif option == "serifs":
-            font_styles["serifs"].add(option)
+        else:
+            font_styles["options"].add(f'{option} = "{value}"')
 
     return (font_name, font_styles, nerdfont)
 

--- a/iosevka-generate
+++ b/iosevka-generate
@@ -55,28 +55,28 @@ def generate_font_plan(
     print(f"Building font with family name: {family_name}")
 
     with open(iosevka_dir / "private-build-plans.toml", "w") as fp:
-        conf = "\n".join(
-            [
-                f"[buildPlans.{font_name}]",
-                f'family = "{font_name}"',
-                *font_styles["options"],
-                "",
-                f"[buildPlans.{font_name}.variants.design]",
-                *font_styles["common"],
-                "",
-                f"[buildPlans.{font_name}.variants.upright]",
-                *font_styles["upright"],
-                "",
-                f"[buildPlans.{font_name}.variants.italic]",
-                *font_styles["italic"],
-                "",
-                f"[buildPlans.{font_name}.variants.oblique]",
-                *font_styles["oblique"],
-                "",
-                f"  [buildPlans.{font_name}.ligations]",
-                f'  inherits = "{" ".join(font_styles["ligations"])}"',
-            ]
-        )
+        sep = """
+            """
+        conf = f"""
+            [buildPlans.{font_name}]
+            family = "{font_name}"
+            {sep.join(font_styles["options"])}
+
+            [buildPlans.{font_name}.variants.design]
+            {sep.join(font_styles["common"])}
+
+            [buildPlans.{font_name}.variants.upright]
+            {sep.join(font_styles["upright"])}
+
+            [buildPlans.{font_name}.variants.italic]
+            {sep.join(font_styles["italic"])}
+
+            [buildPlans.{font_name}.variants.oblique]
+            {sep.join(font_styles["oblique"])}
+
+            [buildPlans.{font_name}.ligations]
+            inherits = "{" ".join(font_styles["ligations"])}"
+        """
 
         print(f"Building iosevka conf:\n{conf}", file=sys.stderr)
         fp.write(dedent(conf))

--- a/iosevka-generate
+++ b/iosevka-generate
@@ -138,7 +138,7 @@ def parse_config(config_file: Path) -> Tuple[str, Dict[str, Set[str]], Optional[
         elif option == "nerdfont":
             nerdfont = value.split(" ")
         elif option == "ligset":
-            font_styles["ligations"].add(option)
+            font_styles["ligations"].add(value)
         else:
             font_styles["options"].add(f'{option} = "{value}"')
 

--- a/iosevka-generate
+++ b/iosevka-generate
@@ -73,8 +73,8 @@ def generate_font_plan(
                 f"[buildPlans.{font_name}.variants.oblique]",
                 *font_styles["oblique"],
                 "",
-                f"[buildPlans.{font_name}.ligations]",
-                f'inherits = "{" ".join(font_styles["ligations"])}"',
+                f"  [buildPlans.{font_name}.ligations]",
+                f'  inherits = "{" ".join(font_styles["ligations"])}"',
             ]
         )
 


### PR DESCRIPTION
In [Iosevka v4.0.0](https://github.com/be5invis/Iosevka/releases/tag/v4.0.0), the `private-build-plans.toml` format was changed, breaking this project. This PR should fix the build-plans generation (though, perhaps in not the most elegant way).

P.S. Thanks for this project, it's making my dotfiles setup a lot easier ^.^